### PR TITLE
Add Attribute by named category and type

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -385,6 +385,15 @@ class PyMISP(object):
             response = self.update_event(event['Event']['id'], event, 'json')
         return self._check_response(response)
 
+    def add_named_attribute(self, event, category, type_value, value, to_ids=False, comment=None, distribution=None, proposal=False):
+        attributes = []
+        if value and category and type:
+            try:
+                attributes.append(self._prepare_full_attribute(category, type_value, value, to_ids, comment, distribution))
+            except NewAttributeError as e:
+                return e
+        return self._send_attributes(event, attributes, proposal)
+
     def add_hashes(self, event, category='Artifacts dropped', filename=None, md5=None, sha1=None, sha256=None, ssdeep=None, comment=None, to_ids=True, distribution=None, proposal=False):
 
         attributes = []


### PR DESCRIPTION
As the title says.

Example:
```
In[3]: from pymisp import PyMISP
In[4]: misp_key = 'api_key'
In[5]: misp_url = 'https://misp.address.com'
In[6]: misp = PyMISP(misp_url, misp_key, True, 'json')
In[7]: event = misp.get_event(1).json()
In[8]: misp.add_named_attribute(event, 'Antivirus detection', 'link', 'https://virustotal.com/report/aaaabbbb')
Out[9]: 
{u'Event': {u'Attribute': [{u'ShadowAttribute': [],
    u'SharingGroup': [],
    u'category': u'Antivirus detection',
    u'comment': u'', . . . . 
```