### PR TITLE
Added STIX retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.pem
 *.pyc
 examples/keys.py
 examples/cudeso.py

--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -217,6 +217,24 @@ class PyMISP(object):
         url = urljoin(self.root_url, 'events/{}'.format(event_id))
         return session.get(url)
 
+    def get_stix_event(self, event_id=None, out_format="json", with_attachments=False, from_date=False, to_date=False, tags=False):
+        """
+            Get an event/events in STIX format
+        """
+        out_format = out_format.lower()
+        if tags:
+          if isinstance(tags, list):
+            tags = "&&".join(tags)
+        
+        session = self.__prepare_session(out_format)
+        url = urljoin(self.root_url, 
+                      "/events/stix/download/{}/{}/{}/{}/{}".format(
+                                        event_id, with_attachments, tags, from_date, to_date
+                                        ))
+        if self.debug:
+          print("Getting STIX event from {}".format(url))  
+        return session.get(url)
+ 
     def add_event(self, event, force_out=None):
         """
             Add a new event
@@ -337,6 +355,10 @@ class PyMISP(object):
 
     def get(self, eid):
         response = self.get_event(int(eid), 'json')
+        return self._check_response(response)
+
+    def get_stix(self, **kwargs):
+        response = self.get_stix_event(**kwargs)
         return self._check_response(response)
 
     def update(self, event):

--- a/tests/test.py
+++ b/tests/test.py
@@ -109,6 +109,10 @@ class TestBasic(unittest.TestCase):
         event = self.misp.get_event(eventid)
         print event.json()
 
+    def get_stix(self, **kwargs):
+        event = self.misp.get_stix(kwargs)
+        print(event)
+
     def add(self):
         event = {u'Event': {u'info': u'This is a test', u'locked': False,
                             u'attribute_count': u'3', u'analysis': u'0',


### PR DESCRIPTION
The API has stix support, but the Python bindings didn't. This is a fix for that.

misp.get_stix(event_id=ID, with_attachment=True/False,
                      from_date=YYYY-MM-DD, to_date=YYYY-MM-DD,
		      tags=["tag1", "tag2"]
	              )

It's a wee bit hacky, but it works.