### PR TITLE
Add a method to add a textual detection name under the 'Antivirus detection' category

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -451,6 +451,11 @@ class PyMISP(object):
         attributes.append(self._prepare_full_attribute(category, 'link', link, to_ids, comment, distribution))
         return self._send_attributes(event, attributes, proposal)
 
+    def add_detection_name(self, event, name, category='Antivirus detection', to_ids=False, comment=None, distribution=None, proposal=False):
+        attributes = []
+        attributes.append(self._prepare_full_attribute(category, 'text', name, to_ids, comment, distribution))
+        return self._send_attributes(event, attributes, proposal)
+
     def add_filename(self, event, filename, category='Artifacts dropped', to_ids=False, comment=None, distribution=None, proposal=False):
         attributes = []
         attributes.append(self._prepare_full_attribute(category, 'filename', filename, to_ids, comment, distribution))


### PR DESCRIPTION
Hi,

I was unable to easily add a textual detection name (and not a link) using PyMISP.
So I added this small method, if you want to add it.

Thanks