### PR TITLE
Return response.text in _check_response when json parsing fails

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -202,6 +202,8 @@ class PyMISP(object):
         try:
             to_return = response.json()
         except ValueError:
+            if response.ok:
+                return {'status': response.ok, 'response': response.text}
             logger.debug(response.text)
             raise PyMISPError('Unknown error: {}'.format(response.text))
 


### PR DESCRIPTION
Return response.text in _check_response when json parsing fails. Useful when getting attachments.