### PR TITLE
Fix suricata_search and new PyMISP methods

### DIFF
--- a/examples/suricata_search/suricata_search.py
+++ b/examples/suricata_search/suricata_search.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""
+https://github.com/raw-data/pymisp-suricata_search
+
+    2017.06.28  start
+    2017.07.03  fixed args.quiet and status msgs
+
+"""
+
 import argparse
 import os
 import queue
@@ -15,7 +23,6 @@ except ImportError as err:
     sys.stderr.write("\t[try] with pip install pymisp\n")
     sys.stderr.write("\t[try] with pip3 install pymisp\n")
     sys.exit(1)
-
 
 HEADER = """
 #This part might still contain bugs, use and your own risk and report any issues.
@@ -150,7 +157,9 @@ def format_request(param, term, misp, quiet, output, thread, noevent):
 
     kwargs = {param: term}
 
-    print ("[+] Searching for: {}".format(kwargs))
+    if not quiet:
+        print ("[+] Searching for: {}".format(kwargs))
+
     search(misp, quiet, noevent, **kwargs)
 
     # collect Suricata rules
@@ -181,7 +190,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    if args.output is not None and os.path.exists(args.output):
+    if args.output is not None and os.path.exists(args.output) and not args.quiet:
         try:
             check = input("[!] Output file {} exists, do you want to continue [Y/n]? ".format(args.output))
             if check not in ["Y","y"]:
@@ -191,8 +200,7 @@ if __name__ == "__main__":
 
     if not args.quiet:
         print ("[i] Connecting to MISP instance: {}".format(misp_url))
-
-    print ("[i] Note: duplicated IDS rules will be removed")
+        print ("[i] Note: duplicated IDS rules will be removed")
 
     # Based on # of terms, format request
     if "," in args.search:
@@ -201,9 +209,8 @@ if __name__ == "__main__":
             misp = init()
             format_request(args.param, term, misp, args.quiet, args.output, args.thread, args.noevent)
     else:
-        if not args.quiet:
-            misp = init()
-            format_request(args.param, args.search, misp, args.quiet, args.output, args.thread, args.noevent)
+        misp = init()
+        format_request(args.param, args.search, misp, args.quiet, args.output, args.thread, args.noevent)
 
     # return collected rules
     return_rules(args.output, args.quiet)

--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -1501,6 +1501,48 @@ class PyMISP(object):
         response = session.get(url)
         return self._check_response(response)
 
+    def view_feeds(self):
+        session = self.__prepare_session()
+        url = urljoin(self.root_url, 'feeds')
+        response = session.get(url)
+        return self._check_response(response)
+
+    def view_feed(self, feed_ids):
+        session = self.__prepare_session()
+        url = urljoin(self.root_url, 'feeds/view/{}'.format(feed_ids))
+        response = session.get(url)
+        return self._check_response(response)
+
+    def cache_feeds_all(self):
+        session = self.__prepare_session()
+        url = urljoin(self.root_url, 'feeds/cacheFeeds/all')
+        response = session.get(url)
+        return self._check_response(response)
+
+    def cache_feed(self, feed_id):
+        session = self.__prepare_session()
+        url = urljoin(self.root_url, 'feeds/cacheFeeds/{}'.format(feed_id))
+        response = session.get(url)
+        return self._check_response(response)
+
+    def cache_feeds_freetext(self):
+        session = self.__prepare_session()
+        url = urljoin(self.root_url, 'feeds/cacheFeeds/freetext')
+        response = session.get(url)
+        return self._check_response(response)
+
+    def cache_feeds_misp(self):
+        session = self.__prepare_session()
+        url = urljoin(self.root_url, 'feeds/cacheFeeds/misp')
+        response = session.get(url)
+        return self._check_response(response)
+
+    def compare_feeds(self):
+        session = self.__prepare_session()
+        url = urljoin(self.root_url, 'feeds/compareFeeds')
+        response = session.get(url)
+        return self._check_response(response)
+
     # ###########################
     # ####### Deprecated ########
     # ###########################


### PR DESCRIPTION
**suricata_search** :
fix args.quiet and status msgs

**PyMISP**:
Exposing more feeds functions (for which  __isRest()_ is available) to the API.

So far, added:

- public function index -> view_feed

- public function view -> view_feeds

- public function cacheFeeds -> cache_feeds_all, cache_feed, cache_feeds_freetext, cache_feeds_misp

- public function compareFeeds -> compare_feeds