### PR TITLE
Let MISP server set default attribute distribution

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -265,7 +265,7 @@ class PyMISP(object):
             misp_event.publish()
         return misp_event
 
-    def _prepare_full_attribute(self, category, type_value, value, to_ids, comment=None, distribution=5, **kwargs):
+    def _prepare_full_attribute(self, category, type_value, value, to_ids, comment=None, distribution=None, **kwargs):
         """Initialize a new MISPAttribute from scratch"""
         misp_attribute = MISPAttribute(self.describe_types)
         misp_attribute.set_all_values(type=type_value, value=value, category=category,

--- a/pymisp/mispevent.py
+++ b/pymisp/mispevent.py
@@ -150,6 +150,8 @@ class MISPAttribute(AbstractMISP):
             if kwargs['type'] not in self.__category_type_mapping[kwargs['category']]:
                 raise NewAttributeError('{} and {} is an invalid combination, type for this category has to be in {}'.format(
                     kwargs.get('type'), kwargs.get('category'), (', '.join(self.__category_type_mapping[kwargs['category']]))))
+        if kwargs.get('distribution') and kwargs['distribution'] is None:
+            kwargs.pop('distribution', None)
         # Required
         self.type = kwargs.pop('type', None)
         if self.type is None:


### PR DESCRIPTION
`distribute=None` is interpreted as 0 (=Organization only) which is probably not what users expect. This patch removes the distribution field from attributes when set to `None` so the server can make that call (based on the `MISP.default_attribute_distribution` server setting).